### PR TITLE
Run 0.0.0-SNAPSHOT releases from main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
         with:
           webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
           webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          color: "#DC143C"
+          color: "#00FF00"
           username: "ExamplePlugin Release Bot"
           message: >
             An ExamplePlugin ${{ env.RELEASE_TYPE }} was deployed:
@@ -154,7 +154,7 @@ jobs:
         with:
           webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
           webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          color: "#DC143C"
+          color: "#FF0000"
           username: "ExamplePlugin Release Bot"
           message: >
             An ExamplePlugin ${{ env.RELEASE_TYPE }} failed:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,18 @@ jobs:
       - build
       - test
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' || github.ref_name == 'main'
     steps:
+      - name: Set snapshot environment
+        if: github.ref_name == 'main'
+        run: |
+          echo "RELEASE_TAG=0.0.0-RC-1" >> $GITHUB_ENV
+
+      - name: Set release environment
+        if: github.ref_type == 'tag'
+        run: |
+          echo "RELEASE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -102,15 +112,16 @@ jobs:
         run: chmod +x gradlew
 
       - name: Publish with Gradle
-        run: ./gradlew -Pver=${{ github.ref_name }} release
+        run: ./gradlew -Pver=${{ env.RELEASE_TAG }} release
 
-      - name: Upload artifact
+      - name: Create Release
         uses: softprops/action-gh-release@v1
+        if: github.ref_type == 'tag'
         with:
           files: ${{ github.workspace }}/build/libs/*
           generate_release_notes: true
           name: ${{ format('Release {0}', github.ref_name) }}
-          prerelease: ${{ endsWith(github.ref_name, '-rc') }}
+          prerelease: ${{ contains(github.ref_name, '-rc-') }}
           fail_on_unmatched_files: true
           draft: true
 
@@ -124,7 +135,7 @@ jobs:
     # Run if on main or tag
     if: always() && (github.ref_name == 'main' || github.ref_type == 'tag')
     steps:
-      - name: Set build environment
+      - name: Set snapshot environment
         if: github.ref_name == 'main'
         run: |
           echo "RELEASE_TYPE=snapshot" >> $GITHUB_ENV

--- a/build.gradle
+++ b/build.gradle
@@ -20,18 +20,21 @@ static def getTime() {
 String shortVersion = null
 if (hasProperty('ver')) {
     if (ver.charAt(0) == "v") {
-        shortVersion = ver.substring(1)
+        shortVersion = ver.substring(1).toUpperCase()
     } else {
-        shortVersion = ver
+        shortVersion = ver.toUpperCase()
     }
 }
 
+// If the tag includes "-RC-" or no tag is supplied, append "-SNAPSHOT"
+int rcIdx = -1
 if (shortVersion == null || shortVersion == "") {
-    shortVersion = getTime()
+    version = getTime() + "-SNAPSHOT"
+} else if ((rcIdx = shortVersion.indexOf("-RC-")) != -1) {
+    version = shortVersion.substring(0, rcIdx) + "-SNAPSHOT"
+} else {
+    version = shortVersion
 }
-
-// Add snapshot identifier to version
-version = shortVersion + "-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -106,25 +109,12 @@ shadowJar {
 jar.enabled = false
 assemble.dependsOn(shadowJar)
 
-task configureRelease {
-    doLast {
-        if (!version.endsWith("-rc")) {
-            // Trim the "-SNAPSHOT" extension from version
-            version = shortVersion
-        }
-    }
-}
-
-// Make sure configuration runs in the correct order
-build.mustRunAfter(configureRelease)
-
 task release {
     dependsOn build
-    dependsOn configureRelease
 
     doLast {
-        // Rename final JAR to trim off version information
-        if (!version.endsWith("-rc")) {
+        if (!version.endsWith("-SNAPSHOT")) {
+            // Rename final JAR to trim off version information
             shadowJar.archiveFile.get().getAsFile()
                     .renameTo(buildDir.toString() + File.separator + 'libs' + File.separator
                             + rootProject.name + '.jar')


### PR DESCRIPTION
Change notification color to correspond with status.

When workflows run from the main branch, they version as 0.0.0-SNAPSHOT. Tags like "vX.Y.Z-rc-N" version as "X.Y.Z-SNAPSHOT". A release is considered a pre-release if it is a tag containing "-rc-".