### PR TITLE
Several Improvements to Workflow.

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -1,0 +1,21 @@
+name: 'Common Setup'
+description: 'Set up JDK and grant execute permissions for gradlew'
+
+inputs:
+  java-version:
+    description: 'Java version'
+    required: true
+    default: '17'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'zulu'
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Allow concurrent run for main, MR, and tag
-  # Disallow concurrent runs on same MRs, tags, and main (triggered by dispatch, schedule, or push)
   group: ${{ format('{0}-{1}', github.job, github.ref) }}
   cancel-in-progress: true
 
@@ -30,15 +28,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Retrieve Project Name
+        run: echo "::set-output name=PROJECT_NAME::$(${{github.workspace}}/gradlew -q printProjectName)"
+        id: project_name
+
+      - name: Get Project Name
+        run: echo "PROJECT_NAME=${{steps.project_name.outputs.PROJECT_NAME}}" >> $GITHUB_ENV
+
+      - name: Common Setup
+        uses: ./.github/actions/common-setup
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
-
-      - name: Grant execute permission for gradlew
-        if: runner.os == 'Linux'
-        run: chmod +x gradlew
 
       - name: Build with Gradle
         run: ./gradlew assemble --info
@@ -48,6 +58,9 @@ jobs:
         with:
           name: ${{ matrix.os }} Java ${{ matrix.java }} build results
           path: ${{ github.workspace }}/build/libs/
+
+    outputs:
+      project_name: ${{ steps.project_name.outputs.PROJECT_NAME }}
 
   test:
     name: Run unit tests
@@ -61,6 +74,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -134,18 +157,20 @@ jobs:
       - release
     # Run if on main or tag
     if: always() && (github.ref_name == 'main' || github.ref_type == 'tag')
+    env:
+      PROJECT_NAME: ${{ needs.build.outputs.project_name }}
     steps:
       - name: Set snapshot environment
         if: github.ref_name == 'main'
         run: |
           echo "RELEASE_TYPE=snapshot" >> $GITHUB_ENV
-          echo "RELEASE_ADDR=https://github.com/CrimsonWarpedcraft/plugin-template/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+          echo "RELEASE_ADDR=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
 
       - name: Set release environment
         if: github.ref_type == 'tag'
         run: |
           echo "RELEASE_TYPE=release" >> $GITHUB_ENV
-          echo "RELEASE_ADDR=https://github.com/CrimsonWarpedcraft/plugin-template/releases/tag/${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "RELEASE_ADDR=https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Notify on success
         if: needs.build.result == 'success' && needs.test.result == 'success' && (needs.release.result == 'success' || github.event_name == 'schedule')
@@ -154,9 +179,9 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
           webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           color: "#00FF00"
-          username: "ExamplePlugin Release Bot"
+          username: "${{ env.PROJECT_NAME }} Release Bot"
           message: >
-            An ExamplePlugin ${{ env.RELEASE_TYPE }} was deployed:
+            An ${{ env.PROJECT_NAME }} ${{ env.RELEASE_TYPE }} was deployed by ${{ github.actor }}:
             ${{ env.RELEASE_ADDR }}
 
       - name: Notify on failure
@@ -166,7 +191,7 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
           webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           color: "#FF0000"
-          username: "ExamplePlugin Release Bot"
+          username: "${{ env.PROJECT_NAME }} Release Bot"
           message: >
-            An ExamplePlugin ${{ env.RELEASE_TYPE }} failed:
-            https://github.com/CrimsonWarpedcraft/plugin-template/actions/runs/${{ github.run_id }}
+            An ${{ env.PROJECT_NAME }} ${{ env.RELEASE_TYPE }} ran by ${{ github.actor }} failed:
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,12 @@ shadowJar {
 jar.enabled = false
 assemble.dependsOn(shadowJar)
 
+tasks.register('printProjectName') {
+    doLast {
+        println rootProject.name
+    }
+}
+
 tasks.register('release') {
     dependsOn build
 
@@ -116,7 +122,7 @@ tasks.register('release') {
         if (!version.endsWith("-SNAPSHOT")) {
             // Rename final JAR to trim off version information
             shadowJar.archiveFile.get().getAsFile()
-                    .renameTo(buildDir.toString() + File.separator + 'libs' + File.separator
+                    .renameTo(layout.buildDirectory.toString() + File.separator + 'libs' + File.separator
                             + rootProject.name + '.jar')
         }
     }


### PR DESCRIPTION
Just want to say how great this template is. I made these changes for myself but thought I may as well push it back and share them! :)

### Added Changes
**Gradle Caching:** This PR includes a step to cache Gradle dependencies, which was not present in the old workflow. This can speed up build times.

```yaml
- name: Cache Gradle dependencies
  uses: actions/cache@v2
  with:
    path: |
      ~/.gradle/caches
      ~/.gradle/wrapper
    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
    restore-keys: |
      ${{ runner.os }}-gradle-
```

**Retrieve Project Name:** This PR has a step to retrieve the project name dynamically from the Gradle configuration. This allows for more flexible notifications and other uses.

```yaml
- name: Retrieve Project Name
  run: echo "::set-output name=PROJECT_NAME::$(${{github.workspace}}/gradlew -q printProjectName)"
  id: project_name
- name: Get Project Name
  run: echo "PROJECT_NAME=${{steps.project_name.outputs.PROJECT_NAME}}" >> $GITHUB_ENV 
```

**Common Setup:** This PR uses a reusable GitHub Action for common setup steps, which was not present in the old workflow.

```yaml
- name: Common Setup
  uses: ./.github/actions/common-setup
  with:
    java-version: ${{ matrix.java }}
```

**Output Variables:** This PR uses output variables to share the project name across multiple jobs.

```yaml
outputs:
  project_name: ${{ steps.project_name.outputs.PROJECT_NAME }}
```

**Notification Environment Variables:** This PR sets the PROJECT_NAME environment variable in the notify job, which allows for dynamic notification messages.

```yaml
env:
  PROJECT_NAME: ${{ needs.build.outputs.project_name }}
```