### PR TITLE
feat(deps): pin Paper API to immutable build versions, drop weekly cron

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ on:
   push:
     branches:
       - 'main'
-  schedule:
-    # PaperMC doesn't change version numbers for latest releases meaning the build may break
-    #   unexpectedly. Build every so often so that we know if a breaking change has been published
-    - cron: '0 0 * * 6'
 
 concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref) }}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Development versions of this repo are pushed to the master branch and are **not*
 | Event             | Plugin Version Format | CI Action                        | GitHub Release Draft? |
 |-------------------|-----------------------|----------------------------------|-----------------------|
 | PR                | yyMMdd-HHmm-SNAPSHOT  | Build and test                   | No                    |
-| Cron              | yyMMdd-HHmm-SNAPSHOT  | Build, test, and notify          | No                    |
 | Push to `main`    | 0.0.0-SNAPSHOT        | Build, test, release, and notify | No                    |
 | Tag `vX.Y.Z-RC-N` | X.Y.Z-SNAPSHOT        | Build, test, release, and notify | Pre-release           |
 | Tag `vX.Y.Z`      | X.Y.Z                 | Build, test, release, and notify | Release               |
@@ -127,7 +126,7 @@ Also, update your dependencies as needed (of course).
 
 ```groovy
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:26.1.2.build.69-stable'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.9.3'
     implementation 'io.papermc:paperlib:1.0.8'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -65,12 +65,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:26.1.2.build.+'
+    compileOnly 'io.papermc.paper:paper-api:26.1.2.build.69-stable'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.9.8'
     implementation 'io.papermc:paperlib:1.0.8'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0'
     testCompileOnly 'com.github.spotbugs:spotbugs-annotations:4.9.8'
-    testImplementation 'io.papermc.paper:paper-api:26.1.2.build.+'
+    testImplementation 'io.papermc.paper:paper-api:26.1.2.build.69-stable'
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.0'
 }


### PR DESCRIPTION
PaperMC now publishes each build as a unique, immutable artifact (e.g. 26.1.2.build.69-stable) instead of a mutable SNAPSHOT  Pinning to a specific build makes the build fully reproducible; Dependabot will bump the version when new stable builds are published, so breaking changes surface in PRs rather than silently on main.

The weekly cron job existed solely to catch unexpected breakage from Paper's old mutable SNAPSHOT releases — that concern no longer applies.