### PR TITLE
fix(ci): exclude cw-commons from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      # Remove when dependabot/dependabot-core#16055 is fixed.
+      exclude:
+        - "com.github.CrimsonWarpedcraft:cw-commons"
     commit-message:
       prefix: "chore(deps):"
     target-branch: "main"


### PR DESCRIPTION
## Summary

- exclude cw-commons from Dependabot's default Gradle cooldown
- preserve cooldown behavior for every other Gradle dependency
- document the upstream Gradle release-date bug that makes the workaround necessary

## Why

Dependabot cannot use versioned-POM Last-Modified dates for ordinary Maven dependencies declared through Gradle. Because JitPack does not expose usable dates in its artifact listing, cw-commons is treated as perpetually inside the default cooldown even though v0.3.2 has been available since August 4.

Upstream: https://github.com/dependabot/dependabot-core/issues/16055

## Validation

- parsed .github/dependabot.yml with Ruby's YAML parser
- git diff --check